### PR TITLE
Nonexistent projects

### DIFF
--- a/lib/terminitor/runner.rb
+++ b/lib/terminitor/runner.rb
@@ -25,7 +25,7 @@ module Terminitor
     end
 
     def project_not_found(project)
-      puts "\nError:  Project #{project} not found.\n"
+      # puts "\nError:  Project #{project} not found.\n"
       usage
     end
 

--- a/test/terminitor_test.rb
+++ b/test/terminitor_test.rb
@@ -39,5 +39,13 @@ context "Terminitor" do
     asserts("runs project") { @test_runner.do_project("foo") }
   end
 
+  context "open wrong project" do
+    setup do
+      @test_item = TestItem.new
+      @test_runner = TestRunner.new
+      stub(@test_runner).app('Terminal') { TestObject.new(@test_item) }
+    end
 
+    asserts("doesn't run project") {  capture(:stdout) { @test_runner.do_project("wrong_project_name") } }.raises(SystemExit)
+  end
 end


### PR DESCRIPTION
I noticed that if you specify a nonexistent project for "terminitor start" the app dies angrily.

$ terminitor start wrong_project_name
/Users/patgeorge/.rvm/gems/ruby-1.8.7-p174/gems/terminitor-0.0.2/lib/terminitor/runner.rb:12:in `do_project': undefined method`each' for false:FalseClass (NoMethodError)
    from /Users/patgeorge/.rvm/gems/ruby-1.8.7-p174/gems/terminitor-0.0.2/lib/terminitor.rb:15:in `start'
    from /Users/patgeorge/.rvm/gems/ruby-1.8.7-p174/gems/thor-0.14.0/lib/thor/task.rb:22:in`send'
    from /Users/patgeorge/.rvm/gems/ruby-1.8.7-p174/gems/thor-0.14.0/lib/thor/task.rb:22:in `run'
    from /Users/patgeorge/.rvm/gems/ruby-1.8.7-p174/gems/thor-0.14.0/lib/thor/invocation.rb:118:in`invoke_task'
    from /Users/patgeorge/.rvm/gems/ruby-1.8.7-p174/gems/thor-0.14.0/lib/thor.rb:246:in `dispatch'
    from /Users/patgeorge/.rvm/gems/ruby-1.8.7-p174/gems/thor-0.14.0/lib/thor/base.rb:389:in`start'
    from /Users/patgeorge/.rvm/gems/ruby-1.8.7-p174/gems/terminitor-0.0.2/bin/terminitor:3
    from /Users/patgeorge/.rvm/gems/ruby-1.8.7-p174/bin/terminitor:19:in `load'
    from /Users/patgeorge/.rvm/gems/ruby-1.8.7-p174/bin/terminitor:19

This fixes that to gracefully error out.  I uncommented out the usage method and tweaked it a bit.  Hope that's ok.

Also I'm not familiar with the riot gem so I was only able to write one test for it which checks for SystemExit.  Ideally I wanted it to also check that it printed the Usage but I couldn't figure that out.  Sorry.

Pat
