### PR TITLE
Untitled

### DIFF
--- a/lib/terminitor.rb
+++ b/lib/terminitor.rb
@@ -65,7 +65,7 @@ module Terminitor
     no_tasks do
       
       def grab_comment_for_file(file)
-        first_line = File.read(file).first
+        first_line = File.new(file).readline.gsub(/\n$/,'')
         first_line =~ /^\s*?#/ ? ("-" + first_line.gsub("#","")) : "\n"
       end
     end


### PR DESCRIPTION
I was getting the following error for `terminator list`:
    > terminitor list
    Global scripts: 
    /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/terminitor-0.0.5/lib/terminitor.rb:68:in `grab_comment_for_file': undefined method`first' for #String:0x00000100a07b88 (NoMethodError)
      from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/terminitor-0.0.5/lib/terminitor.rb:34:in `block in list'
      from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/terminitor-0.0.5/lib/terminitor.rb:33:in`each'
      from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/terminitor-0.0.5/lib/terminitor.rb:33:in `list'
      from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/thor-0.14.1/lib/thor/task.rb:22:in`run'
      from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/thor-0.14.1/lib/thor/invocation.rb:118:in `invoke_task'
      from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/thor-0.14.1/lib/thor.rb:246:in`dispatch'
      from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/thor-0.14.1/lib/thor/base.rb:389:in `start'
      from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/terminitor-0.0.5/bin/terminitor:3:in`<top (required)>'
      from /Users/tim/.rvm/gems/ruby-1.9.2-p0/bin/terminitor:19:in `load'
      from /Users/tim/.rvm/gems/ruby-1.9.2-p0/bin/terminitor:19:in`<main>'

When `grab_comment_for_file` was called, the file path would be passed as a string. `File.read(file)` would return the file contents as a string, instead of as an array. I'm seeing this behavior in ruby 1.9.2 and 1.8.6.

If we first create a File object, and then call readline on it, we get the first line of the file (including its trailing `\n`). I think this is what was intended, and it works for ruby 1.9.2 and 1.8.6.

Here's the result of `rake test`:

```
> rake test              
(in /Users/tim/Sites/terminitor)
/Users/tim/.rvm/rubies/ruby-1.9.2-p0/bin/ruby -I"lib:lib:test" "/Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake/rake_test_loader.rb" "test/terminitor_test.rb" 
...
3 passes, 0 failures, 0 errors in 0.190266 seconds
/Users/tim/Sites/terminitor/lib/terminitor.rb:68:in `grab_comment_for_file': private method `readline' called for #<FakeFS::File:0x00000100b35d98> (NoMethodError)
    from /Users/tim/Sites/terminitor/lib/terminitor.rb:34:in `block in list'
    from /Users/tim/Sites/terminitor/lib/terminitor.rb:33:in `each'
    from /Users/tim/Sites/terminitor/lib/terminitor.rb:33:in `list'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/thor-0.14.1/lib/thor/task.rb:22:in `run'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/thor-0.14.1/lib/thor/invocation.rb:118:in `invoke_task'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/thor-0.14.1/lib/thor.rb:246:in `dispatch'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/thor-0.14.1/lib/thor/base.rb:389:in `start'
    from test/terminitor_test.rb:20:in `block (4 levels) in <top (required)>'
    from /Users/tim/Sites/terminitor/test/teststrap.rb:19:in `capture'
    from test/terminitor_test.rb:20:in `block (3 levels) in <top (required)>'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot/situation.rb:8:in `instance_eval'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot/situation.rb:8:in `setup'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot/runnable.rb:17:in `run'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot/context.rb:184:in `block in local_run'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot/context.rb:184:in `each'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot/context.rb:184:in `local_run'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot/context.rb:178:in `run'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot/context.rb:205:in `block in run_sub_contexts'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot/context.rb:205:in `each'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot/context.rb:205:in `run_sub_contexts'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot/context.rb:179:in `run'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot.rb:19:in `block (2 levels) in run'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot.rb:19:in `each'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot.rb:19:in `block in run'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot/reporter.rb:16:in `summarize'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot.rb:18:in `run'
    from /Users/tim/.rvm/gems/ruby-1.9.2-p0/gems/riot-0.11.4/lib/riot.rb:46:in `block in <module:Riot>'
rake aborted!
Command failed with status (1): [/Users/tim/.rvm/rubies/ruby-1.9.2-p0/bin/r...]
```

Looks like FakeFS keeps `readline` private, but ruby's File lib doesn't...?
