### PR TITLE
Terminal settings

### DIFF
--- a/lib/templates/example.term.tt
+++ b/lib/templates/example.term.tt
@@ -7,11 +7,15 @@ setup 'echo "setup"'
 tab "echo 'default'", "echo 'default tab'"
 
 window do
+
   tab "echo 'first tab'", "echo 'of window'"
   
-  tab "named tab" do
+  tab "named tab", :settings => "Ocean" do
     run "echo 'named tab'"
     run "ls"
   end
 end
 
+window "autotest" do 
+  tab "echo 'window and tab without options'"
+end

--- a/lib/terminitor.rb
+++ b/lib/terminitor.rb
@@ -4,6 +4,7 @@ require File.expand_path('../terminitor/dsl', __FILE__)
 require File.expand_path('../terminitor/runner', __FILE__)
 require File.expand_path('../terminitor/abstract_core', __FILE__)
 require File.expand_path('../terminitor/cli', __FILE__)
+require File.expand_path('../terminitor/abstract_capture', __FILE__)
 
 module Terminitor
   autoload :Version, File.expand_path('../terminitor/version', __FILE__)
@@ -11,8 +12,10 @@ module Terminitor
   when %r{darwin}
     require 'appscript'
     autoload :MacCore,     File.expand_path('../terminitor/cores/mac_core', __FILE__)
+    autoload :MacCapture,  File.expand_path('../terminitor/capture/mac_capture', __FILE__)    
   when %r{linux}
     require 'dbus'
     autoload :KonsoleCore, File.expand_path('../terminitor/cores/konsole_core', __FILE__)
+    autoload :KonsoleCapture,  File.expand_path('../terminitor/capture/konsole_capture', __FILE__)        
   end
 end

--- a/lib/terminitor/abstract_capture.rb
+++ b/lib/terminitor/abstract_capture.rb
@@ -1,0 +1,36 @@
+module Terminitor
+  # This AbstractCapture defines the basic methods that the Capture class should inherit
+  class AbstractCapture
+    # Generates .term file from settings of currently opened terminal windows and tabs
+    def capture_settings
+      capture_windows.inject("") do |config, w|
+        config << generate_object_dsl('window', w) do |dsl|
+          w[:tabs].each do |t|
+            dsl << generate_object_dsl('tab', t, 4)
+          end
+        end
+      end
+    end
+  
+    # Returns array of settings of currently opened windows, 
+    # [{:options => {:window_option1 => ... }, :tabs => [{:options => {:tab_option1 => ... }}]}]
+    # Needs to be defined for specific platform
+    def capture_windows
+    end
+    
+    private
+    
+    # Helper method to generate the .term file
+    def generate_object_dsl(name, object, ident = 0, &block)
+      dsl, margin = "", " "*ident
+
+      params = object[:options].inject([]) do |params, option|
+        params << ":#{option[0]} => #{option[1].inspect}"
+      end.join(", ")
+
+      dsl << margin + "#{name} #{params} do\n"
+      yield(dsl) if block_given?
+      dsl << margin + "end\n\n"
+    end
+  end
+end

--- a/lib/terminitor/capture/konsole_capture.rb
+++ b/lib/terminitor/capture/konsole_capture.rb
@@ -1,0 +1,8 @@
+module Terminitor
+  # Captures terminal windows and tabs for Linux   
+  class KonsoleCapture < AbstractCapture    
+    def initialize
+      super
+    end
+  end
+end

--- a/lib/terminitor/capture/mac_capture.rb
+++ b/lib/terminitor/capture/mac_capture.rb
@@ -1,0 +1,51 @@
+module Terminitor
+  # Captures terminal windows and tabs for Mac OS X 
+  class MacCapture < AbstractCapture
+    include Appscript
+    
+    # Defines what options of window or tab to capture and how
+    # just in case we'll need to get other properties
+    OPTIONS_MASK = {
+      :window => {
+        :bounds => "bounds"
+      },
+      :tab => {
+        :settings => "current_settings.name"
+      }
+    }
+    
+    # Initialize @terminal with Terminal.app, Load the Windows, store the Termfile
+    # Terminitor::MacCore.new('/path')
+    def initialize
+      @terminal = app('Terminal.app')
+    end
+
+    # Returns settings of currently opened windows and tabs.    
+    def capture_windows
+      windows = []
+      # for some reason terminal.windows[] contain duplicated elements
+      @terminal.windows.get.uniq.each do |window| 
+        if window.visible.get
+          tabs = window.tabs.get.inject([]) do |tabs, tab|
+            tabs << {:options => object_options(tab)}
+          end
+          windows << {:options => object_options(window), :tabs => tabs}
+        end
+      end
+      windows
+    end
+    
+    # Returns hash of options of window or tab
+    def object_options(object)
+      options = {}
+      class_ =  object.class_.get
+      if class_ && OPTIONS_MASK[class_]
+        OPTIONS_MASK[class_].each_pair do |option, getter|
+          value = object.instance_eval(getter).get
+          options[option] = value
+        end
+      end
+      options
+    end
+  end
+end

--- a/lib/terminitor/cli.rb
+++ b/lib/terminitor/cli.rb
@@ -43,10 +43,28 @@ module Terminitor
     method_option :root,    :type => :string, :default => '.',    :aliases => '-r'
     method_option :editor,  :type => :string, :default => nil,    :aliases => '-c'
     method_option :syntax,  :type => :string, :default => 'term', :aliases => '-s'
+    method_option :capture, :type => :boolean,   :default => false,  :aliases => '-g'
     def edit(project="")
       syntax = project.empty? ? 'term' : options[:syntax] # force Termfile to use term syntax
       path =  config_path(project, syntax.to_sym)
-      template "templates/example.#{syntax}.tt", path, :skip => true
+      if options[:capture] && !File.exists?(path)
+        # capture settings of currently opened windows and tabs
+        if syntax == 'term'
+          if core = capture_core(RUBY_PLATFORM)
+            term = core.new().capture_settings
+            (f = File.new(path, "w") << term).close
+          else
+            say("No suitable core found!")
+            return
+          end
+        else
+          say "Terminal settings can be captured only to DSL format."
+          return
+        end
+      else 
+        # use standard template
+        template "templates/example.#{syntax}.tt", path, :skip => true
+      end
       open_in_editor(path,options[:editor])
     end
 

--- a/lib/terminitor/cores/konsole_core.rb
+++ b/lib/terminitor/cores/konsole_core.rb
@@ -18,7 +18,7 @@ module Terminitor
     end
 
     # Opens a new tab and returns itself.
-    def open_tab
+    def open_tab(options = nil)
       session_number = @konsole.newSession
       session_object = @konsole_service.object("/Sessions/#{session_number}")
       session_object.introspect
@@ -26,7 +26,7 @@ module Terminitor
     end
 
     # Opens a new window and returns the tab object.
-    def open_window
+    def open_window(options = nil)
       session_number = @konsole.currentSession
       session_object = @konsole_service.object("/Sessions/#{session_number}")
       session_object.introspect

--- a/lib/terminitor/dsl.rb
+++ b/lib/terminitor/dsl.rb
@@ -26,10 +26,15 @@ module Terminitor
     end
 
     # sets command context to be run inside a specific window
-    # window('new window') { tab('ls','gitx') }
-    def window(name = nil, &block)
-      window_tabs = @windows[name || "window#{@windows.keys.size}"] = {}
-      @_context, @_old_context = window_tabs, @_context
+    # window(:name => 'new window', :size => [80,30], :position => [9, 100]) { tab('ls','gitx') }
+    # window { tab('ls', 'gitx') }
+    def window(name =nil, options = nil, &block)
+      options ||= {}
+      options, name = name, nil if name.is_a?(Hash)    
+      window_name = name || "window#{@windows.keys.size}"
+      window_contents = @windows[window_name] = {:tabs => {}}
+      window_contents[:options] = options unless options.empty?
+      @_context, @_old_context = window_contents[:tabs], @_context
       instance_eval(&block)
       @_context = @_old_context
     end
@@ -41,17 +46,20 @@ module Terminitor
     end
 
     # sets command context to be run inside specific tab
-    # tab('new tab') { run 'mate .' }
+    # tab(:name => 'new tab', :settings => 'Grass') { run 'mate .' }
     # tab 'ls', 'gitx'
-    def tab(name= nil, *commands, &block)
+    def tab(name = nil, options = nil, *commands, &block)
+      options ||= {}
       if block_given?
-        tab_tasks = @_context[name || "tab#{@_context.keys.size}"] = []
-        @_context, @_old_context = tab_tasks, @_context
+        options, name = name, nil if name.is_a?(Hash)    
+        tab_name = name || "tab#{@_context.keys.size}"
+        tab_contents = @_context[tab_name] = {:commands => []}
+        tab_contents[:options] = options unless options.empty?
+        @_context, @_old_context = tab_contents[:commands], @_context
         instance_eval(&block)
         @_context = @_old_context
       else
-        tab_tasks = @_context["tab#{@_context.keys.size}"] = []
-        tab_tasks.concat([name] + commands)
+        tab_tasks = @_context["tab#{@_context.keys.size}"] = { :commands => [name] + [options] +commands}
       end
     end
 
@@ -59,7 +67,6 @@ module Terminitor
     def to_hash
       { :setup => @setup, :windows => @windows }
     end
-
 
     private
 

--- a/lib/terminitor/runner.rb
+++ b/lib/terminitor/runner.rb
@@ -11,6 +11,15 @@ module Terminitor
       else nil
       end
     end
+    
+    # Defines how to capture terminal settings on the specified platform
+    def capture_core(platform)
+      core = case platform.downcase
+      when %r{darwin} then Terminitor::MacCapture
+      when %r{linux}  then Terminitor::KonsoleCapture # TODO check for gnome and others
+      else nil
+      end
+    end
 
     # Execute the core with the given method.
     # execute_core :process!, 'project'

--- a/test/abstract_capture_test.rb
+++ b/test/abstract_capture_test.rb
@@ -1,0 +1,36 @@
+require File.expand_path('../teststrap', __FILE__)
+
+context "AbstractCapture" do
+  context "capture_settings" do 
+    setup do
+      @capture = Terminitor::AbstractCapture.new()
+      any_instance_of(Terminitor::AbstractCapture) do |core|
+        stub(core).capture_windows  { [
+          {:options => {:size => [10,20], :name => "main window"}, 
+           :tabs => [
+             {:options => {:settings => "Grass"}}
+             ]},
+          {:options => {:size => [14,30], :name => "another window"},
+           :tabs => [{:options => {:settings => "Yello"}}]}
+        ] }
+      end
+    end
+    
+    setup { @capture.capture_settings() }
+    asserts_topic.equivalent_to <<-OUTPUT
+window :size => [10, 20], :name => "main window" do
+    tab :settings => "Grass" do
+    end
+
+end
+
+window :size => [14, 30], :name => "another window" do
+    tab :settings => "Yello" do
+    end
+
+end
+
+OUTPUT
+
+  end
+end

--- a/test/abstract_core_test.rb
+++ b/test/abstract_core_test.rb
@@ -20,57 +20,77 @@ context "AbstractCore" do
     context "without default" do
       setup do
         any_instance_of(Terminitor::AbstractCore) do |core|
-          stub(core).load_termfile('/path/to')  { {:windows => {'tab1' => ['ls', 'ok'], 'default' => [] } } }
+          stub(core).load_termfile('/path/to')  { {:windows => {'window1' => {:tabs => {'tab1' => ['ls', 'ok']}}, 'default' => [] }} }
         end
       end
       setup { @core = Terminitor::AbstractCore.new('/path/to') }
-      setup { mock(@core).run_in_window(['ls', 'ok']) }
+      setup { mock(@core).run_in_window('window1', {:tabs => {'tab1' => ['ls', 'ok']}}) }
       asserts("ok") { @core.process! }
     end
 
     context "with default" do
       setup do
         any_instance_of(Terminitor::AbstractCore) do |core|
-          stub(core).load_termfile('/path/to')  { {:windows => {'tab1' => ['ls', 'ok'], 'default' => ['echo'] } } }
+          stub(core).load_termfile('/path/to')  { {:windows => {'window1' => {:tabs => {'tab1' => ['ls', 'ok']}}, 'default' => {:tabs => {'tab0' => ['echo']} } }} }
         end
       end
       setup { @core = Terminitor::AbstractCore.new('/path/to') }
-      setup { mock(@core).run_in_window(['echo'], :default => true) }
-      setup { mock(@core).run_in_window(['ls', 'ok']) }
+      setup { mock(@core).run_in_window('default',{:tabs => {'tab0'=>['echo']}}, :default => true) }
+      setup { mock(@core).run_in_window('window1', {:tabs => {'tab1' => ['ls', 'ok']}}) }
       asserts("ok") { @core.process! }
     end
 
   end
 
   context "run_in_window" do
-    setup do
-      any_instance_of(Terminitor::AbstractCore) do |core|
-        stub(core).load_termfile('/path/to')  { true }
+    context "without options" do 
+      setup do
+        any_instance_of(Terminitor::AbstractCore) do |core|
+          stub(core).load_termfile('/path/to')  { {:windows => {'window1' => {:tabs => {'tab1' => {:commands => ['ls', 'ok']}, 'tab2' => {:commands => ['ps']}}}}} }
+        end
+        @core = Terminitor::AbstractCore.new('/path/to')
       end
-      @core = Terminitor::AbstractCore.new('/path/to')
+
+      context "without default" do
+        setup { mock(@core).open_window(nil)          { "first"  } }
+        setup { mock(@core).open_tab(nil)             { "second"  } }  
+        setup { mock(@core).set_delayed_options       { true      } }  
+        setup { mock(@core).execute_command('ls', :in => "first")  }
+        setup { mock(@core).execute_command('ok', :in => "first")  }
+        setup { mock(@core).execute_command('ps', :in => "second")  }        
+        asserts("ok") { @core.process! }
+      end
+
+      context "with default" do
+        setup { mock(@core).open_tab(nil) { true  } }        
+        setup { mock(@core).execute_command('echo', :in => true)  }
+        asserts("ok") { @core.run_in_window('default',{:tabs => {'tab0'=>{:commands => ['echo']}}}, :default => true)}
+      end
+
+      context "with working_dir" do
+        setup { stub(Dir).pwd { '/tmp/path' } }
+        setup { mock(@core).execute_command("cd \"/tmp/path\"", :in => '/tmp/path')  }
+        setup { mock(@core).execute_command('ls', :in => '/tmp/path')  }
+        asserts("ok") { @core.run_in_window('window1', {:tabs => {'tab1' => {:commands => ['ls']}}}) }
+      end
     end
-
-    context "with default" do
-      setup { mock(@core).open_window { true  } }
-      setup { mock(@core).open_tab    { true  } }
-      setup { mock(@core).execute_command('ls', :in => true)  }
-      setup { mock(@core).execute_command('ok', :in => true)  }
-      asserts("ok") { @core.run_in_window('tab' => ['ls','ok']) }
-    end
-
-    context "without default" do
-      setup { mock(@core).open_tab { true  } }
-      setup { mock(@core).execute_command('ls', :in => true)  }
-      setup { mock(@core).execute_command('ok', :in => true)  }
-      asserts("ok") { @core.run_in_window({'tab' => ['ls','ok']}, :default => true) }
-    end
-
-
-    context "with working_dir" do
-      setup { stub(Dir).pwd { '/tmp/path' } }
-      setup { mock(@core).execute_command("cd \"/tmp/path\"", :in => '/tmp/path')  }
-      setup { mock(@core).execute_command('ls', :in => '/tmp/path')  }
-      asserts("ok") { @core.run_in_window({'tab' => ['ls']}) }
+    
+    context "with options" do 
+      setup do
+        any_instance_of(Terminitor::AbstractCore) do |core|
+          stub(core).load_termfile('/path/to') { {:windows => {'window1' => {:tabs => {'tab1' => {:commands => ['ls', 'ok'], :options => {:settings => 'cool', :name => 'first tab'}}, 'tab2' => {:commands => ['ps'], :options => {:settings => 'grass', :name => 'second tab'}},  }, :options => {:bounds => [10,10]}}}} }
+        end
+        @core = Terminitor::AbstractCore.new('/path/to')
+      end
+      
+      setup { mock(@core).open_window(:bounds => [10,10], :settings => 'cool', :name => "first tab")  { "first"  } }
+      setup { mock(@core).open_tab(:settings => 'grass', :name => 'second tab')    { "second"  } }
+      setup { mock(@core).set_delayed_options { true  } }       
+      setup { mock(@core).execute_command('ls', :in => "first")  }
+      setup { mock(@core).execute_command('ok', :in => "first")  }
+      setup { mock(@core).execute_command('ps', :in => "second")  }
+      
+      asserts("ok") { @core.process! }
     end
   end
 

--- a/test/capture/mac_capture_test.rb
+++ b/test/capture/mac_capture_test.rb
@@ -1,0 +1,42 @@
+require File.expand_path('../../teststrap',__FILE__)
+
+if platform?("darwin") # Only run test if it's darwin
+  context "MacCapture" do
+    # Stub out the initialization
+    setup do
+      @terminal = Object.new
+      any_instance_of(Terminitor::MacCapture) do |core|
+        stub(core).app('Terminal.app') { @terminal  }
+      end 
+    end
+    setup { @mac_capture = Terminitor::MacCapture.new() }
+
+    context "capture_windows" do 
+      setup do 
+        window, tab = Object.new, Object.new
+        stub(@terminal).windows.stub!.get { [window]}
+        stub(window).tabs.stub!.get {[tab]}
+        stub(window).visible.stub!.get { true }
+        mock(@mac_capture).object_options(window) { {:window_option => true} }
+        mock(@mac_capture).object_options(tab)    { {:tab_option => true} }        
+        # any_instance_of(Terminitor::MacCapture) {|core| stub(core).object_options(anything) { {} }}
+      end
+      setup { @mac_capture.capture_windows}
+      asserts_topic.equals [{:tabs=>[{:options=>{:tab_option=>true}}], :options=>{:window_option=>true}}]
+    end
+
+    context "object_options" do
+      setup do
+        @object = Object.new
+        stub(@object).class_.stub!.get { :window }
+        stub(@object).bounds.stub!.get { [10,20,30,40]}
+      end
+      setup { @mac_capture.object_options(@object) }
+      asserts_topic.equals { {:bounds => [10,20,30,40]} }
+    end
+  end
+else
+  context "MacCore" do
+    puts "Nothing to do, you are not on OSX"
+  end
+end

--- a/test/dsl_test.rb
+++ b/test/dsl_test.rb
@@ -6,10 +6,10 @@ context "Dsl" do
   asserts_topic.assigns :setup
   asserts_topic.assigns :windows
   asserts_topic.assigns :_context
-
+ 
   context "to_hash" do
     setup { @yaml.to_hash }
-    asserts_topic.equivalent_to(:setup=>["echo \"setup\""], :windows=>{"window1"=>{"named tab"=>["echo 'named tab'", "ls"], "tab0"=>["echo 'first tab'", "echo 'of window'"]}, "default"=>{"tab0"=>["echo 'default'", "echo 'default tab'"]}})
+    asserts_topic.equivalent_to(:setup=>["echo \"setup\""], :windows=>{"window1"=>{:tabs=>{"named tab"=>{:commands=>["echo 'named tab'", "ls"], :options => {:settings=>"Grass"}}, "tab0"=>{:commands=>["echo 'first tab'", "echo 'of window'"]}}, :options => {:size=>[70,30]}}, "default"=>{"tab0"=>{:commands=>["echo 'default'", "echo 'default tab'"]}}})
   end
 
 end

--- a/test/fixtures/bar.term
+++ b/test/fixtures/bar.term
@@ -5,12 +5,13 @@ setup 'echo "setup"'
 
 tab "echo 'default'", "echo 'default tab'"
 
-window do
+window :size => [70,30] do
   tab "echo 'first tab'", "echo 'of window'"
   
-  tab "named tab" do
+  tab "named tab", :settings => "Grass" do
     run "echo 'named tab'"
     run "ls"
   end
 end
+
 

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -38,6 +38,13 @@ context "Runner" do
       end
     end
   end
+  
+  context "capture_core" do 
+    context "for Darwin" do
+      setup { @test_runner.capture_core('darwin') }
+      asserts_topic.equals Terminitor::MacCapture
+    end
+  end
 
   context "open_in_editor" do
     context "using $EDITOR" do


### PR DESCRIPTION
So I created another topic branch with all the commits in one patch, rebased against the latest master. 

DSL syntax extended to allow window and tab settings, for example

window :bounds => [50, 301, 1035, 777] do
  tab :settings => "Ocean", :selected => true do
    run "ls"
  end

  tab "my green tab", :settings => "Grass" do
  end
end
Currently supported options: :bounds, :miniaturized and :visible for a window, and :settings, :selected, :miniaturized, :visible for a tab.

And second, settings of currenlty opened terminal windows and tabs can be saved to .term file so you don't need to add settings manually. To do this, run

terminitor edit myproject --capture
So now I can quickly set up configuration which I used to - with ssh to remote in the green tab, mongo console in the blue tab, autotest in a separate window in the bottom of the second monitor etc. Could be useful to somebody else (though works only on Mac OS X for now).

Old DSL syntax supported as well.
