### PR TITLE
Fix for problem with miniaturized windows (issue #43)

### DIFF
--- a/lib/terminitor/cores/mac_core.rb
+++ b/lib/terminitor/cores/mac_core.rb
@@ -6,7 +6,7 @@ module Terminitor
     
     ALLOWED_OPTIONS = {
       :window => [:bounds, :visible, :miniaturized],
-      :tab => [:settings, :selected, :miniaturized, :visible]
+      :tab => [:settings, :selected]
     }
     
     # Initialize @terminal with Terminal.app, Load the Windows, store the Termfile
@@ -81,6 +81,8 @@ module Terminitor
           object.frame.set(value)
           object.position.set(value)
         when :selected # works for tabs, for example tab :active => true
+          delayed_option(option, value, object)
+        when :miniaturized # works for windows only
           delayed_option(option, value, object)
         else # trying to apply any other option
           begin


### PR DESCRIPTION
Hi again! Here is a fix for [issue 43](https://github.com/achiu/terminitor/issues/#issue/43). In fact, there were 2 problems: first, :miniaturized was in the list of options available for tabs, which is wrong, and second, it has to be a delayed option, that is should be applied after everything else is done.
