### PR TITLE
Fix test errors on 1.8.6

### DIFF
--- a/lib/terminitor/abstract_core.rb
+++ b/lib/terminitor/abstract_core.rb
@@ -37,7 +37,8 @@ module Terminitor
         tab_name    = tab_options[:name] if tab_options
         if first_tab && !options[:default]
           first_tab = false
-          window_options = Hash[window_options.to_a + tab_options.to_a] # safe merge
+          combined_options = (window_options.to_a + tab_options.to_a).inject([]) {|arr, pair| arr += pair }
+          window_options = Hash[*combined_options] # safe merge
           tab = window_options.empty? ? open_window(nil) : open_window(window_options)
         else
           tab = ( tab_key == 'default' ? active_window : open_tab(tab_options) ) # give us the current window if its default, else open a tab.

--- a/lib/terminitor/cores/mac_core.rb
+++ b/lib/terminitor/cores/mac_core.rb
@@ -128,7 +128,8 @@ module Terminitor
     
     # selects options allowed for window or tab
     def allowed_options(object_type, options)
-      Hash[ options.select {|option, value| ALLOWED_OPTIONS[object_type].include?(option) }]
+      pairs = options.select {|option, value| ALLOWED_OPTIONS[object_type].include?(option) }.inject([]) {|arr, pair| arr += pair }
+      Hash[*pairs]
     end
     
     # Add option to the list of delayed options

--- a/test/cores/mac_core_test.rb
+++ b/test/cores/mac_core_test.rb
@@ -81,7 +81,7 @@ if platform?("darwin") # Only run test if it's darwin
 
     context "set_options" do 
       setup do 
-        @object, @terminal, @windows= 3.times.collect { Object.new }
+        @object, @terminal, @windows = Array.new(3) { Object.new }
         stub(@terminal).windows { @windows }
         any_instance_of(Terminitor::MacCore) do |core|
           stub(core).app('Terminal')           { @terminal }


### PR DESCRIPTION
All tests should be passing on 1.8.6 now. (Except for AbstractCapture#capture_settings, but you probably know about that one already. It's fine, just the hash is out of order so the actual string is different from the expected string, but it's equivalent.)
