### PR TITLE
(very) basic iTerm support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    terminitor (0.2.2)
+    terminitor (0.3.1)
       github (~> 0.4.5)
       rb-appscript
       thor (~> 0.14.0)

--- a/lib/terminitor.rb
+++ b/lib/terminitor.rb
@@ -1,6 +1,6 @@
 lib_dir = File.expand_path("..", __FILE__)
 $:.unshift( lib_dir ) unless $:.include?( lib_dir )
-
+      
 require 'terminitor/yaml'
 require 'terminitor/dsl'
 require 'terminitor/runner'
@@ -15,6 +15,8 @@ module Terminitor
     require 'appscript'
     autoload :MacCore,        'terminitor/cores/mac_core'
     autoload :MacCapture,     'terminitor/capture/mac_capture'  
+    autoload :ItermCore,      'terminitor/cores/iterm_core'
+    autoload :ItermCapture,   'terminitor/capture/iterm_capture' 
   when %r{linux}
     require 'dbus'
     autoload :KonsoleCore,    'terminitor/cores/konsole_core'

--- a/lib/terminitor/capture/iterm_capture.rb
+++ b/lib/terminitor/capture/iterm_capture.rb
@@ -1,0 +1,51 @@
+module Terminitor
+  # Captures terminal windows and tabs for Mac OS X 
+  class ItermCapture < AbstractCapture
+    include Appscript
+    
+    # Defines what options of window or tab to capture and how
+    # just in case we'll need to get other properties
+    OPTIONS_MASK = {
+      :window => {
+        :bounds => "bounds"
+      },
+      :tab => {
+        :settings => "current_settings.name"
+      }
+    }
+    
+    # Initialize @terminal with Terminal.app, Load the Windows, store the Termfile
+    # Terminitor::MacCore.new('/path')
+    def initialize
+      @terminal = app('iTerm.app')
+    end
+
+    # Returns settings of currently opened windows and tabs.    
+    def capture_windows
+      windows = []
+      # for some reason terminal.windows[] contain duplicated elements
+      @terminal.windows.get.uniq.each do |window| 
+        if window.visible.get
+          tabs = window.tabs.get.inject([]) do |tabs, tab|
+            tabs << {:options => object_options(tab)}
+          end
+          windows << {:options => object_options(window), :tabs => tabs}
+        end
+      end
+      windows
+    end
+    
+    # Returns hash of options of window or tab
+    def object_options(object)
+      options = {}
+      class_ =  object.class_.get
+      if class_ && OPTIONS_MASK[class_]
+        OPTIONS_MASK[class_].each_pair do |option, getter|
+          value = object.instance_eval(getter).get
+          options[option] = value
+        end
+      end
+      options
+    end
+  end
+end

--- a/lib/terminitor/cores/iterm_core.rb
+++ b/lib/terminitor/cores/iterm_core.rb
@@ -1,0 +1,140 @@
+module Terminitor
+  # Mac OS X Core for Terminitor
+  # This Core manages all the interaction with Appscript and the Terminal
+  class ItermCore < AbstractCore
+    include Appscript
+    
+    ALLOWED_OPTIONS = {
+      :window => [:bounds, :visible, :miniaturized],
+      :tab => [:settings, :selected]
+    }
+    
+    # Initialize @terminal with Terminal.app, Load the Windows, store the Termfile
+    # Terminitor::MacCore.new('/path')
+    def initialize(path)
+      super
+      @terminal = app('iTerm')
+      @windows  = @terminal.terminals
+      @delayed_options = []
+    end
+            
+    # executes the given command via appscript
+    # execute_command 'cd /path/to', :in => #<tab>
+    def execute_command(cmd, options = {})      
+      if options[:in]
+        options[:in].write(:text => "#{cmd}")
+      else
+        active_window.write(:text => "#{cmd}")
+      end
+    end
+
+    # Opens a new tab and returns itself.
+    # TODO : handle options (?)
+    def open_tab(options = nil)
+      session = @terminal.current_terminal.sessions.end.make( :new => :session )
+      session.exec(:command => ENV['SHELL'])
+      session
+    end
+    
+    # Opens A New Window, applies settings to the first tab and returns the tab object.
+    # TODO : handle options (?)
+    def open_window(options = nil)
+      window  = @terminal.make( :new => :terminal )
+      session = window.sessions.end.make( :new => :session )
+      session.exec(:command => ENV['SHELL'])
+      session
+    end
+
+    # Returns the Terminal Process
+    # We need this method to workaround appscript so that we can instantiate new tabs and windows.
+    # otherwise it would have looked something like window.make(:new => :tab) but that doesn't work.
+    def terminal_process
+      app("System Events").application_processes["iTerm.app"]
+    end
+    
+    # Returns the last instantiated tab from active window
+    def return_last_tab
+      @terminal.current_terminal.sessions.last.get rescue false
+    end
+
+    # returns the active window
+    def active_window
+      @terminal.current_terminal.current_session.get
+    end
+    
+    # Sets options of the given object
+    def set_options(object, options = {})
+      options.each_pair do |option, value| 
+        case option
+        when :settings   # works for windows and tabs, for example :settings => "Grass"
+          begin
+            object.current_settings.set(@terminal.settings_sets[value])
+          rescue Appscript::CommandError => e
+            puts "Error: invalid settings set '#{value}'"
+          end
+        when :bounds # works only for windows, for example :bounds => [10,20,300,200]
+          # the only working sequence to restore window size and position! 
+          object.bounds.set(value)
+          object.frame.set(value)
+          object.position.set(value)
+        when :selected # works for tabs, for example tab :active => true
+          delayed_option(option, value, object)
+        when :miniaturized # works for windows only
+          delayed_option(option, value, object)
+        when :name
+          # ignore it.
+        else # trying to apply any other option
+          begin
+            object.instance_eval(option.to_s).set(value)
+          rescue
+            puts "Error setting #{option} = #{value} on #{object.inspect}"
+          end
+        end
+      end
+    end
+    
+    # Apply delayed options and remove them from the queue
+    def set_delayed_options
+      @delayed_options.length.times do 
+        option = @delayed_options.shift
+        option[:object].instance_eval(option[:option]).set(option[:value])
+      end
+    end
+
+    private
+    
+    # These methods are here for reference so I can ponder later
+    # how I could possibly use them.
+    # And Currently aren't tested. =(
+    
+    # returns a window by the id
+    def window_by_id(id)
+      @windows.ID(id)
+    end
+
+    # grabs the window id.
+    def window_id(window)
+      window.id_.get
+    end
+
+    # set_window_title #<Window>, "hi"
+    # Note: This sets all the windows to the same title.
+    def set_window_title(window, title)
+      window.custom_title.set(title)
+    end
+    
+    # selects options allowed for window or tab
+    def allowed_options(object_type, options)
+      Hash[ options.select {|option, value| ALLOWED_OPTIONS[object_type].include?(option) }]
+    end
+    
+    # Add option to the list of delayed options
+    def delayed_option(option, value, object)
+      @delayed_options << {
+        :option => option.to_s, 
+        :value => value, 
+        :object => object
+      }
+    end
+  end
+end

--- a/lib/terminitor/runner.rb
+++ b/lib/terminitor/runner.rb
@@ -6,7 +6,12 @@ module Terminitor
     # find_core RUBY_PLATFORM
     def find_core(platform)
       core = case platform.downcase
-      when %r{darwin} then Terminitor::MacCore
+      when %r{darwin} then 
+        if ENV['TERM_PROGRAM'] == 'iTerm.app'
+          Terminitor::ItermCore
+        else
+          Terminitor::MacCore
+        end
       when %r{linux}  then Terminitor::KonsoleCore # TODO check for gnome and others
       else nil
       end
@@ -15,7 +20,12 @@ module Terminitor
     # Defines how to capture terminal settings on the specified platform
     def capture_core(platform)
       core = case platform.downcase
-      when %r{darwin} then Terminitor::MacCapture
+      when %r{darwin} then 
+        if ENV['TERM_PROGRAM'] == 'iTerm.app'
+          Terminitor::ItermCapture
+        else
+          Terminitor::MacCapture
+        end
       when %r{linux}  then Terminitor::KonsoleCapture # TODO check for gnome and others
       else nil
       end
@@ -109,4 +119,5 @@ module Terminitor
     end
 
   end
+  
 end


### PR DESCRIPTION
Hey guys, this seems to be the bare minimum to get iTerm working - iterm_capture.rb is a direct copy of mac_capture, so there's probably a cleaner way to do it other than copying the whole file.

I'm not very happy with the lib/terminitor.rb or lib/terminitor/runner.rb stuff i did - there needs to be a more extensible way to support multiple clients on a platform, but I just kind of threw this together for my own use.

I've had a go at adding an iterm_core_test.rb but i can't figure out how to get the window option tests to pass - I don't really use the options stuff and unfortunately I don't have time at the moment to write proper tests :( I haven't committed any of the test stuff since it's a bit of a mess.

Anyway feel free to ignore this or use any of iterm_core.rb that you want - I haven't changed much from mac_core.rb and i'm not even sure what i've changed is correct, but it seems to work for the basic terminitor commands i've been using.

thanks for your hard work - much appreciated!
