### PR TITLE
Ruby dbus dependency

### DIFF
--- a/terminitor.gemspec
+++ b/terminitor.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   case RUBY_PLATFORM.downcase
   when %r{darwin}
     s.add_dependency "rb-appscript"
+  when %r{linux}
+    s.add_dependency "ruby-dbus"
   else
   end
   


### PR DESCRIPTION
Hey, here's a tiny patch to make life easier for us poor sods working in Linux ;-)

It adds the ruby-dbus gem as a dependency when RUBY_PLATFORM contains "linux".
