### PR TITLE
Fix tests on linux

### DIFF
--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -28,10 +28,12 @@ context "Runner" do
 
 
   context "#find_core" do
-    if ENV['TERM_PROGRAM'] == 'iTerm.app'
-      should("have Darwin") { @test_runner.find_core('darwin') }.equals Terminitor::ItermCore
-    else
-      should("have Darwin") { @test_runner.find_core('darwin') }.equals Terminitor::MacCore
+    if platform?('darwin')
+      if ENV['TERM_PROGRAM'] == 'iTerm.app'
+        should("have Darwin") { @test_runner.find_core('darwin') }.equals Terminitor::ItermCore
+      else
+        should("have Darwin") { @test_runner.find_core('darwin') }.equals Terminitor::MacCore
+      end
     end
 
     if platform?('linux') # TODO Gotta be a better way.
@@ -40,10 +42,12 @@ context "Runner" do
   end
   
   context "#capture_core" do 
-    if ENV['TERM_PROGRAM'] == 'iTerm.app'
-      should("have Darwin") { @test_runner.capture_core('darwin') }.equals Terminitor::ItermCapture
-    else
-      should("have Darwin") { @test_runner.capture_core('darwin') }.equals Terminitor::MacCapture
+    if platform?('darwin')
+      if ENV['TERM_PROGRAM'] == 'iTerm.app'
+        should("have Darwin") { @test_runner.capture_core('darwin') }.equals Terminitor::ItermCapture
+      else
+        should("have Darwin") { @test_runner.capture_core('darwin') }.equals Terminitor::MacCapture
+      end
     end
   end
 


### PR DESCRIPTION
Another small change, this one surrounds the mac-only tests in the #find_core and #capture_core contexts with "if platform?('darwin')" so that they don't cause errors on Linux (where it seems e.g. Terminitor::MacCore is undefined).
