### PR TITLE
Check if growlnotify found

### DIFF
--- a/test.watchr
+++ b/test.watchr
@@ -3,10 +3,12 @@ system 'clear'
 
 def growl(message)
   growlnotify = `which growlnotify`.chomp
-  title = "Watchr Test Results"
-  image = message.include?('0 failures, 0 errors') ? "~/.watchr_images/passed.png" : "~/.watchr_images/failed.png"
-  options = "-w -n Watchr --image '#{File.expand_path(image)}' -m '#{message}' '#{title}'"
-  system %(#{growlnotify} #{options} &)
+  if not growlnotify.empty?
+    title = "Watchr Test Results"
+    image = message.include?('0 failures, 0 errors') ? "~/.watchr_images/passed.png" : "~/.watchr_images/failed.png"
+    options = "-w -n Watchr --image '#{File.expand_path(image)}' -m '#{message}' '#{title}'"
+    system %(#{growlnotify} #{options} &)
+  end
 end
 
 def run(cmd)


### PR DESCRIPTION
Here's one more small thing: when calling growl() in the watchr file, check the result of `which growlnotify` and don't proceed if it's the empty string. This fixes watchr for platforms without growlnotify.
