### PR TITLE
Allow (background) commands started with "&"

### DIFF
--- a/lib/terminitor/dsl.rb
+++ b/lib/terminitor/dsl.rb
@@ -50,7 +50,7 @@ module Terminitor
       else
         current = @_context
       end
-      current << commands.join(" && ")
+      current << commands.map { |c| "(#{c})" }.join(" && ")
     end
 
     # runs commands before each tab in window context


### PR DESCRIPTION
With the current && implementation of commands it isn't possible to start commands ending with "&".

With this patch the following is possible:

```
tab 'Log (test)', :settings => 'Ocean' do
  run 'mate . &', 
      'gitx &', 
      'tail -f log/test.log'
end
```

I obviously use of the final "&" to speed up the whole process but it's probably only one of its possible uses.
