### PR TITLE
run command broken. removed parentheses in dsl

### DIFF
--- a/lib/terminitor/dsl.rb
+++ b/lib/terminitor/dsl.rb
@@ -50,7 +50,7 @@ module Terminitor
       else
         current = @_context
       end
-      current << commands.map { |c| "(#{c})" }.join(" && ")
+      current << commands.map { |c| "#{c}" }.join(" && ")
     end
 
     # runs commands before each tab in window context


### PR DESCRIPTION
For some reason, nothing worked. 
The commands where called with parentheses i.e. (mate .). So besides having textmate trying to
load '/' and crashing everything is okay.

I removed the parentheses and everything is okay now.
