### PR TITLE
ignore emacs backup files (*~) in "terminitor list"

### DIFF
--- a/lib/terminitor/cli.rb
+++ b/lib/terminitor/cli.rb
@@ -29,7 +29,7 @@ module Terminitor
     desc "list", "lists all terminitor scripts"
     def list
       say "Global scripts: \n"
-      Dir.glob("#{TERM_PATH}/*").each do |file|
+      Dir.glob("#{TERM_PATH}/*[^~]").each do |file|
         say "  * #{File.basename(file, '.term')} #{grab_comment_for_file(file)}"
       end
     end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -24,10 +24,14 @@ context "Terminitor" do
     setup do
       File.open(terminitor_root('foo.yml'),"w") { |f| f.puts @template }
       File.open(terminitor_root('bar.yml'),"w") { |f| f.puts @template }
+      File.open(terminitor_root('baz.term'),"w") { |f| f.puts @template }
+      File.open(terminitor_root('baz.term~'),"w") { |f| f.puts @template }
       capture(:stdout) { Terminitor::Cli.start(['list']) }
     end
     asserts_topic.matches %r{foo\.yml - COMMENT OF SCRIPT HERE}
-    asserts_topic.matches %r{bar\.yml - COMMENT OF SCRIPT HERE}
+    asserts_topic.matches %r{bar\.yml - COMMENT OF SCRIPT HERE}   # yaml style
+    asserts_topic.matches %r{baz - COMMENT OF SCRIPT HERE}        # .term style
+    denies_topic.matches %r{baz\.term~ - COMMENT OF SCRIPT HERE}  # backup files
   end
 
   asserts "#init creates .terminitor" do


### PR DESCRIPTION
Minor change, but I noticed that the glob for CLI was picking up backup files if you use emacs as your editor.  Also beefed up the test for new .term types.
