### PR TITLE
Fix setting name of a tab so that it doesn't mess with the displayed command history

### DIFF
--- a/lib/terminitor/abstract_core.rb
+++ b/lib/terminitor/abstract_core.rb
@@ -53,7 +53,7 @@ module Terminitor
         # clean up prompt
         tab_content[:commands].insert(0, 'clear') if tab_name || !@working_dir.to_s.empty?
         # add title to tab
-        tab_content[:commands].insert(0, "PS1=$PS1\"\\e]2;#{tab_name}\\a\"") if tab_name
+        tab_content[:commands].insert(0, "PS1=\"$PS1\\e]2;#{tab_name}\\a\"") if tab_name
         tab_content[:commands].insert(0, "cd \"#{@working_dir}\"") unless @working_dir.to_s.empty?
         tab_content[:commands].each { |cmd| execute_command(cmd, :in => tab) }
       end

--- a/test/abstract_core_test.rb
+++ b/test/abstract_core_test.rb
@@ -123,11 +123,11 @@ context "AbstractCore" do
         mock(core).open_window(:bounds => [10,10], :settings => 'cool', :name => "first tab")  { "first"  }
         mock(core).open_tab(:settings => 'grass', :name => 'second tab')    { "second"  }
         mock(core).set_delayed_options { true  }
-        mock(core).execute_command('PS1=$PS1"\e]2;first tab\a"', :in => 'first')
+        mock(core).execute_command('PS1="$PS1\e]2;first tab\a"', :in => 'first')
         mock(core).execute_command('clear', :in => 'first')
         mock(core).execute_command('ls', :in => "first")
         mock(core).execute_command('ok', :in => "first")
-        mock(core).execute_command('PS1=$PS1"\e]2;second tab\a"', :in => 'second')
+        mock(core).execute_command('PS1="$PS1\e]2;second tab\a"', :in => 'second')
         mock(core).execute_command('clear', :in => 'second')
         mock(core).execute_command('ps', :in => "second")
         core.process!


### PR DESCRIPTION
See the commit message for more information on what the deal is here.
