### PR TITLE
added a simple bash_completion script

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1,0 +1,30 @@
+_terminitor() 
+{
+    local cur prev opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    #
+    #  The basic options we'll complete.
+    #
+    opts="create delete edit fetch help init list open setup start update"
+
+
+    #
+    #  Complete the arguments to some of the basic commands.
+    #
+    case "${prev}" in
+    start)
+      local running=$(for x in `terminitor list | egrep -e '^  \* ' | awk '{ print $2 }'`; do echo ${x} ; done )
+      COMPREPLY=( $(compgen -W "${running}" -- ${cur}) )
+      return 0
+      ;;
+    *)
+      ;;
+    esac
+
+   COMPREPLY=($(compgen -W "${opts}" -- ${cur}))  
+   return 0
+}
+complete -F _terminitor terminitor


### PR DESCRIPTION
I have added a basic bash_completion script. It can be used as a starting point (it only completes the list of projects for start now because this is what I need the most).
To use it, just source bash_completion from your bashrc or bash_profile.
