### PR TITLE
Simple error message fix

### DIFF
--- a/lib/terminitor/runner.rb
+++ b/lib/terminitor/runner.rb
@@ -118,9 +118,9 @@ module Terminitor
     # @example return_error_message 'hi
     def return_error_message(project)
       unless project.empty?
-        say "'#{project}' doesn't exist! Please run 'terminitor open #{project.gsub(/\..*/,'')}'"
+        say "'#{project}' doesn't exist! Please run 'terminitor edit #{project.gsub(/\..*/,'')}'"
       else
-        say "Termfile doesn't exist! Please run 'terminitor open' in project directory"
+        say "Termfile doesn't exist! Please run 'terminitor edit' in project directory"
       end
     end
 


### PR DESCRIPTION
When trying to start a project that doesn't exist, terminitor currently recommends running 'terminitor open <project_name>' which is a depreciated command. This pull request simply fixes that message to use 'terminitor edit'
