### PR TITLE
Changed platform detection in gemspec.  Allows installation on Ubuntu

### DIFF
--- a/terminitor.gemspec
+++ b/terminitor.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path("../lib/terminitor/version", __FILE__)
+require 'rbconfig'
 
 Gem::Specification.new do |s|
   s.name        = "terminitor"
@@ -15,7 +16,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "terminitor"
   
   # Platform Specific Dependencies
-  case RUBY_PLATFORM.downcase
+  case Config::CONFIG['host_os'].downcase
   when %r{darwin}
     s.add_dependency "rb-appscript", "~>0.6.1"
   when %r{linux}


### PR DESCRIPTION
Hi,

```
 I couldn't install this on Ubuntu 11.04, rubygems 1.8.6 before, and after changing the platform detection code, it now works for me.  Just thought i'd share..
```
