### PR TITLE
Use ordered hashes to further fix 1.8 compat issues

### DIFF
--- a/lib/terminitor.rb
+++ b/lib/terminitor.rb
@@ -1,7 +1,8 @@
 lib_dir = File.expand_path("..", __FILE__)
 $:.unshift( lib_dir ) unless $:.include?( lib_dir )
-      
+
 require 'terminitor/yaml'
+require 'terminitor/ordered_hash'
 require 'terminitor/dsl'
 require 'terminitor/runner'
 require 'terminitor/abstract_core'

--- a/lib/terminitor/ordered_hash.rb
+++ b/lib/terminitor/ordered_hash.rb
@@ -1,0 +1,183 @@
+
+# Copied from rails @ c495bfc127405f7ead0d1c275c4d75682a51e00e
+# and then modified to remove YAML stuff as we don't need that
+module Terminitor
+  # The order of iteration over hashes in Ruby 1.8 is undefined. For example, you do not know the
+  # order in which +keys+ will return keys, or +each+ yield pairs. <tt>ActiveSupport::OrderedHash</tt>
+  # implements a hash that preserves insertion order, as in Ruby 1.9:
+  #
+  #   oh = ActiveSupport::OrderedHash.new
+  #   oh[:a] = 1
+  #   oh[:b] = 2
+  #   oh.keys # => [:a, :b], this order is guaranteed
+  #
+  # <tt>ActiveSupport::OrderedHash</tt> is namespaced to prevent conflicts with other implementations.
+  class OrderedHash < ::Hash #:nodoc:
+    # Hash is ordered in Ruby 1.9!
+    if RUBY_VERSION < '1.9'
+
+      # In MRI the Hash class is core and written in C. In particular, methods are
+      # programmed with explicit C function calls and polymorphism is not honored.
+      #
+      # For example, []= is crucial in this implementation to maintain the @keys
+      # array but hash.c invokes rb_hash_aset() originally. This prevents method
+      # reuse through inheritance and forces us to reimplement stuff.
+      #
+      # For instance, we cannot use the inherited #merge! because albeit the algorithm
+      # itself would work, our []= is not being called at all by the C code.
+
+      def initialize(*args, &block)
+        super
+        @keys = []
+      end
+
+      def self.[](*args)
+        ordered_hash = new
+
+        if (args.length == 1 && args.first.is_a?(Array))
+          args.first.each do |key_value_pair|
+            next unless (key_value_pair.is_a?(Array))
+            ordered_hash[key_value_pair[0]] = key_value_pair[1]
+          end
+
+          return ordered_hash
+        end
+
+        unless (args.size % 2 == 0)
+          raise ArgumentError.new("odd number of arguments for Hash")
+        end
+
+        args.each_with_index do |val, ind|
+          next if (ind % 2 != 0)
+          ordered_hash[val] = args[ind + 1]
+        end
+
+        ordered_hash
+      end
+
+      def initialize_copy(other)
+        super
+        # make a deep copy of keys
+        @keys = other.keys
+      end
+
+      def []=(key, value)
+        @keys << key unless has_key?(key)
+        super
+      end
+
+      def delete(key)
+        if has_key? key
+          index = @keys.index(key)
+          @keys.delete_at index
+        end
+        super
+      end
+
+      def delete_if
+        super
+        sync_keys!
+        self
+      end
+
+      def reject!
+        super
+        sync_keys!
+        self
+      end
+
+      def reject(&block)
+        dup.reject!(&block)
+      end
+
+      def keys
+        @keys.dup
+      end
+
+      def values
+        @keys.collect { |key| self[key] }
+      end
+
+      def to_hash
+        self
+      end
+
+      def to_a
+        @keys.map { |key| [ key, self[key] ] }
+      end
+
+      def each_key
+        return to_enum(:each_key) unless block_given?
+        @keys.each { |key| yield key }
+        self
+      end
+
+      def each_value
+        return to_enum(:each_value) unless block_given?
+        @keys.each { |key| yield self[key]}
+        self
+      end
+
+      def each
+        return to_enum(:each) unless block_given?
+        @keys.each {|key| yield [key, self[key]]}
+        self
+      end
+
+      def each_pair
+        return to_enum(:each_pair) unless block_given?
+        @keys.each {|key| yield key, self[key]}
+        self
+      end
+
+      alias_method :select, :find_all
+
+      def clear
+        super
+        @keys.clear
+        self
+      end
+
+      def shift
+        k = @keys.first
+        v = delete(k)
+        [k, v]
+      end
+
+      def merge!(other_hash)
+        if block_given?
+          other_hash.each { |k, v| self[k] = key?(k) ? yield(k, self[k], v) : v }
+        else
+          other_hash.each { |k, v| self[k] = v }
+        end
+        self
+      end
+
+      alias_method :update, :merge!
+
+      def merge(other_hash, &block)
+        dup.merge!(other_hash, &block)
+      end
+
+      # When replacing with another hash, the initial order of our keys must come from the other hash -ordered or not.
+      def replace(other)
+        super
+        @keys = other.keys
+        self
+      end
+
+      def invert
+        OrderedHash[self.to_a.map!{|key_value_pair| key_value_pair.reverse}]
+      end
+
+      def inspect
+        "#<OrderedHash #{super}>"
+      end
+
+      private
+        def sync_keys!
+          @keys.delete_if {|k| !has_key?(k)}
+        end
+    end
+  end
+end

--- a/test/dsl_test.rb
+++ b/test/dsl_test.rb
@@ -5,7 +5,7 @@ context "Dsl" do
   asserts_topic.assigns :setup
   asserts_topic.assigns :windows
   asserts_topic.assigns :_context
- 
+
   context "to_hash" do
     setup { topic.to_hash }
     asserts(:[],:setup).equals ["echo \"setup\""]
@@ -93,7 +93,7 @@ context "with panes" do
   asserts_topic.assigns :setup
   asserts_topic.assigns :windows
   asserts_topic.assigns :_context
- 
+
   context "creates correct hash" do
     setup { topic.to_hash }
 


### PR DESCRIPTION
I have this Termfile:

``` ruby
window do
  tab :name => "guard" do
    run "j campfire; bundle exec guard"
  end

  tab :name => "console" do
    run "j campfire; d"
  end
end
```

I have noticed all of a sudden that when I run terminitor, the "guard" tab will open in another window, but the "console" tab will open in the current window. If I patch AbstractCore#process! to tell me what the windows hash is, it is this:

``` ruby
{:term_windows=>
  {"window1"=>
    {:tabs=>
      {"default"=>{:commands=>[]},
       "tab1"=>
        {:commands=>["j campfire; bundle exec guard"],
         :options=>{:name=>"guard"}}}},
   "default"=>
    {:tabs=>
      {"default"=>{:commands=>[]},
       "tab1"=>{:commands=>["j campfire; d"], :options=>{:name=>"console"}}}}}}
```

I have tracked this down to #last_open_window in AbstractCore. It appears that under Ruby 1.8, this does not always return the last open window but in fact could return _any_ of the windows. This is because it uses keys.last to pull the last window from the windows hash. However, since hashes in 1.8 are of course unordered, this is non-deterministic.

I have fixed this by copying the OrderedHash class from ActiveSupport and using that to store windows and tabs. Coincidentally, the tests for DSL, which currently fail on 1.8, now pass (and if there were any other files that failed, they now pass too).
