### PR TITLE
expand ~ when loading global path

### DIFF
--- a/lib/consular/dsl.rb
+++ b/lib/consular/dsl.rb
@@ -31,7 +31,7 @@ module Consular
       @_windows            = ActiveSupport::OrderedHash.new
       @_windows['default'] = window_hash
       @_context            = @_windows['default']
-      file = File.read(path)
+      file = File.read(File.expand_path(path))
       if path =~ /\.yml$/
         @_file = YAML.load file
         extend Yaml


### PR DESCRIPTION
If c.global_path specified in consularc contains a '~', it should be expanded.
I noticed that if I specified c.global_path = "~/path/from/my/home" in my consularc, consular would fail to load my project files claiming that  "~/path/from/my/home" doesn't exist (even when it did) because it wasn't expanding the '~'.
