### PR TITLE
Changes README gnome link to ruby gems page

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Some of the cores that are available are:
  * [OSX](http://www.github.com/achiu/consular-osx) - Mac OS X Terminal
  * [iTerm](https://github.com/achiu/consular-iterm) - Mac OS X iTerm
  * [Terminator](https://github.com/ilkka/consular-terminator) - Terminator
- * [Gnome](https://github.com/jc00ke/consular-gnome-terminal) - Gnome Terminal
+ * [Gnome](https://rubygems.org/gems/consular-gnome-terminal/versions/0.1.1) - Gnome Terminal
 
 Feel free to contribute more cores so that Consular can support your terminal of choice :)
 


### PR DESCRIPTION
The GitHub page for the gnome-terminal is down so I've updated the README to link directly to the gem page.